### PR TITLE
Change single-item simmer recipes to proceed and discard the extra

### DIFF
--- a/Block/BlockSaucepan.cs
+++ b/Block/BlockSaucepan.cs
@@ -292,6 +292,8 @@ namespace ACulinaryArtillery
             }
             else return null;
 
+            if (amount <= 0) return null; // nothing to show for a sub-portion dribble that won't cook
+
             if (GetContainableProps(product) is WaterTightContainableProps props)
             {
                 float millilitres = (float) Math.Round((float)amount * product.StackSize * 1000 / props.ItemsPerLitre);

--- a/Block/BlockSaucepan.cs
+++ b/Block/BlockSaucepan.cs
@@ -92,7 +92,7 @@ namespace ACulinaryArtillery
                 if ((combustProps?.SmeltedStack?.ResolvedItemstack != null) &&                  //there is an output item defined and correctly resolved
                     combustProps.SmeltingType is EnumSmeltType.Cook or EnumSmeltType.Convert && //it's an item you cook rather than smelting
                     combustProps.RequiresContainer &&                                           //it requires a container
-                    (stacks[0].StackSize % combustProps.SmeltedRatio == 0))                     //there is a round number of items to smelt
+                    (stacks[0].StackSize >= combustProps.SmeltedRatio))                         //there is at least one whole portion to smelt (partial amounts cook too; DoSmelt throws the extra away)
                 {
                     return true;
                 }

--- a/Block/BlockSaucepan.cs
+++ b/Block/BlockSaucepan.cs
@@ -270,6 +270,7 @@ namespace ACulinaryArtillery
             List<ItemStack> contents = [.. inv.Skip(3).Select(slot => slot.Itemstack).Where(stack => stack != null)];
             ItemStack? product = null;
             int amount = 0;
+            string wasteText = "";  //a warning about leftovers we'll throw away, if there are any
 
             if (contents.Count == 1)
             {
@@ -281,9 +282,20 @@ namespace ACulinaryArtillery
                 if (product == null) return null;
 
                 amount = contents[0].StackSize / contents[0].Collectible.CombustibleProps.SmeltedRatio;
+
+                //anything left over after the last whole batch gets discarded when it cooks, so warn about it up front
+                int wastedItems = contents[0].StackSize % contents[0].Collectible.CombustibleProps.SmeltedRatio;
+
+                if (wastedItems > 0)
+                {
+                    wasteText = " " + (GetContainableProps(contents[0]) is WaterTightContainableProps wasteProps ?
+                                       Lang.Get("aculinaryartillery:firepit-gui-willwaste-liquid", VolumeText(wastedItems, wasteProps), contents[0].GetName()) :
+                                       Lang.Get("aculinaryartillery:firepit-gui-willwaste", wastedItems, contents[0].GetName()));
+                }
             }
             else if (contents.Count > 1 && api.GetSimmerRecipes().FirstOrDefault(rec => rec.Match(contents) > 0) is SimmerRecipe match)
             {
+                //simmer recipes only match exact multiples of their ingredients, so nothing is ever left over here
                 product = match.Simmering.SmeltedStack.ResolvedItemstack;
 
                 if (product == null) return null;
@@ -294,14 +306,21 @@ namespace ACulinaryArtillery
 
             if (amount <= 0) return null; // nothing to show for a sub-portion dribble that won't cook
 
-            if (GetContainableProps(product) is WaterTightContainableProps props)
-            {
-                float millilitres = (float) Math.Round((float)amount * product.StackSize * 1000 / props.ItemsPerLitre);
+            string text = GetContainableProps(product) is WaterTightContainableProps props ?
+                          Lang.Get("mealcreation-nonfood-liquid", VolumeText(amount * product.StackSize, props), product.GetName()) :
+                          Lang.Get("firepit-gui-willcreate", amount, product.GetName());
 
-                return Lang.Get("mealcreation-nonfood-liquid", millilitres < 100 ? Lang.Get("{0} mL", millilitres) : Lang.Get("{0:0.##} L", millilitres / 1000), product.GetName());
-            }
+            return text + wasteText;
+        }
 
-            return Lang.Get("firepit-gui-willcreate", amount, product.GetName());
+        /// <summary>
+        /// Renders a number of containable items as millilitres or litres, whichever reads better.
+        /// </summary>
+        static string VolumeText(int items, WaterTightContainableProps props)
+        {
+            float millilitres = (float) Math.Round((float)items * 1000 / props.ItemsPerLitre);
+
+            return millilitres < 100 ? Lang.Get("{0} mL", millilitres) : Lang.Get("{0:0.##} L", millilitres / 1000);
         }
 
         public MeshData? GenRightMesh(ICoreClientAPI capi, ItemStack contentStack, BlockPos? forBlockPos = null, bool isSealed = false)

--- a/assets/aculinaryartillery/lang/en.json
+++ b/assets/aculinaryartillery/lang/en.json
@@ -328,6 +328,9 @@
   "aculinaryartillery:handbook-createdby-mixingbowl": "Kneading",
   "aculinaryartillery:handbook-createdby-simmering": "Simmering",
   
+  "aculinaryartillery:firepit-gui-willwaste-liquid": "(will waste {0} of {1})",
+  "aculinaryartillery:firepit-gui-willwaste": "(will waste {0}x {1})",
+
   "aculinaryartillery:Will make {0}" : "Will make {0}",
   "aculinaryartillery:made with " : "made with ",
   "aculinaryartillery:and " : "and ",


### PR DESCRIPTION
Currently, if you have 100 mL of maple sap in a saucepan/cauldron, the firepit UI will say "will make 20mL of maple syrup" but the cauldron will sit in the "Cold" state consuming fuel endlessly. This is because the recipe batch size is 40mL, so nothing happens if you don't have an exact multiple of 40mL. This is extremely confusing when you encounter it the first time.

This PR changes the implementation to, for single-input simmer recipes, proceed as long as there is at least one batch's worth, and simply discard the extra. It seems to be quite complicated/messy to code this to retain the extra input in the cooking slots (or anywhere else), so I have reasoned that usually you're simmering multiple liters of juice/sap and won't miss the lost <40mL.

As far as I can tell, all the current single-input simmer recipes are such that this would be an acceptable loss. If you did this change to the multi-item recipes, you would create much bigger losses, which is why I only changed the single-input case.