### PR TITLE
Fix handbook CreatedBy ordering

### DIFF
--- a/Util/HandbookInfoExtensions.cs
+++ b/Util/HandbookInfoExtensions.cs
@@ -11,6 +11,12 @@ namespace ACulinaryArtillery.Util
 {
     public static class HandbookInfoExtensions
     {
+
+        public static RichTextComponentBase? GetSubHeading(List<RichTextComponentBase> components, string code)
+        {
+            return components.FirstOrDefault(comp => (comp as RichTextComponent)?.DisplayText == "• " + Lang.Get(code) + "\n");
+        }
+
         public static List<RichTextComponentBase> ACAHandbookIngredientForComponents(ICoreClientAPI capi, ItemStack[] allStacks, ActionConsumable<string> openDetailPageFor, ItemStack stack)
         {
             ItemStack maxstack = stack.Clone();
@@ -96,7 +102,6 @@ namespace ACulinaryArtillery.Util
 
             List<RichTextComponentBase> components = [];
             var verticalSpace = new ClearFloatTextComponent(capi, 7);
-            components.Add(verticalSpace);
 
             if (kneadingRecipes.Length > 0)
             {

--- a/Util/Patches.cs
+++ b/Util/Patches.cs
@@ -892,9 +892,9 @@ namespace ACulinaryArtillery
             }
             else
             {
-                var beforeSubheading = components.FirstOrDefault(comp => (comp as RichTextComponent)?.DisplayText == "� " + Lang.Get("Baking (in oven)") + "\n");
-                beforeSubheading ??= components.FirstOrDefault(comp => (comp as RichTextComponent)?.DisplayText == "� " + Lang.Get("handbook-createdby-potcooking") + "\n");
-                beforeSubheading ??= components.FirstOrDefault(comp => (comp as RichTextComponent)?.DisplayText == "� " + Lang.Get("Crafting") + "\n");
+                var beforeSubheading = HandbookInfoExtensions.GetSubHeading(components, "Baking (in oven)");
+                beforeSubheading ??= HandbookInfoExtensions.GetSubHeading(components, "handbook-createdby-potcooking");
+                beforeSubheading ??= HandbookInfoExtensions.GetSubHeading(components, "Crafting");
                 int insertIndex = components.Count;
                 if (beforeSubheading != null) insertIndex = components.IndexOf(beforeSubheading);
                 components.InsertRange(insertIndex, newComponents);
@@ -922,10 +922,10 @@ namespace ACulinaryArtillery
             }
             else
             {
-                var displaySubheading = components.FirstOrDefault(comp => (comp as RichTextComponent)?.DisplayText == "� " + Lang.Get("handbook-storable-displaycontainers") + "\n");
-                var beforeSubheading = components.FirstOrDefault(comp => (comp as RichTextComponent)?.DisplayText == "� " + Lang.Get("handbook-storable-liquidcontainers") + "\n");
-                beforeSubheading ??= components.FirstOrDefault(comp => (comp as RichTextComponent)?.DisplayText == "� " + Lang.Get("handbook-storable-foodcontainers") + "\n");
-                beforeSubheading ??= components.FirstOrDefault(comp => (comp as RichTextComponent)?.DisplayText == "� " + Lang.Get("handbook-storable-animalhusbandry") + "\n");
+                var displaySubheading = HandbookInfoExtensions.GetSubHeading(components, "handbook-storable-displaycontainers");
+                var beforeSubheading = HandbookInfoExtensions.GetSubHeading(components, "handbook-storable-liquidcontainers");
+                beforeSubheading ??= HandbookInfoExtensions.GetSubHeading(components, "handbook-storable-foodcontainers");
+                beforeSubheading ??= HandbookInfoExtensions.GetSubHeading(components, "handbook-storable-animalhusbandry");
                 int insertIndex = components.Count - 1;
                 if (beforeSubheading != null) insertIndex = components.IndexOf(beforeSubheading);
                 if (displaySubheading != null) components.InsertRange(insertIndex, newComponents);


### PR DESCRIPTION
Actual fix for #131. Instead of potentially creating 2 newlines, we actually wanted the ACA entries to come first.