### PR TITLE
Fixed: Crash when creating cached meal recipe stacks with no handbook stacks

### DIFF
--- a/Util/HandbookInfoExtensions.cs
+++ b/Util/HandbookInfoExtensions.cs
@@ -248,7 +248,8 @@ namespace ACulinaryArtillery.Util
 
         public static Dictionary<CookingRecipeIngredient, HashSet<ItemStack?>>? CreateCachedMealRecipeStacks(ICoreClientAPI capi, CookingRecipe recipe)
         {
-            ItemStack[] allstacks = ObjectCacheUtil.TryGet<ItemStack[]>(capi, "handbookallstacks");
+            ItemStack[]? allstacks = ObjectCacheUtil.TryGet<ItemStack[]>(capi, "handbookallstacks");
+            if (allstacks == null) return null;
 
             return ObjectCacheUtil.GetOrCreate(capi, "valstacksbying-" + recipe.Code, () =>
             {


### PR DESCRIPTION
Crash log reported on Discord, caused by dereferencing `allStacks` when `ObjectCacheUtil.TryGet` failed.

```
Running on 64 bit Windows 10.0.26200.0 with 65253 MB RAM
Game Version: v1.22.7 (Stable)
8/30/2026 5:41:18 PM: Critical error occurred
Loaded Mods: walkingstick@3.0.10, bettercrates@1.10.0, chiseltools@1.17.6, craftablecompanion@1.5.4, crawlanddive@0.2.5, creaturefootsteps@1.3.0, vichnybackpack@3.4.4, extrachests@1.11.0, extraruins@1.0.4, floralzonescaperegion@1.0.35, floralzonescentralaustralianregion@1.0.25, floralzonescosmopolitanregion@1.0.12, floralzoneseastasiaticregion@1.0.22, floralzonesmediterraneanregion@1.0.22, floralzonesneozeylandicregion@1.0.22, fajousting@1.0.5, fatemplar@1.4.6, favarangian@1.1.0, faviking@1.1.6, bovinae@0.3.6, caninae@1.1.8, capreolinae@2.0.16, elephantidae@1.0.18, machairodontinae@1.1.11, pantherinae@1.2.17, sirenia@1.0.30, fruitrefreshed@1.1.0, geoaddons@1.4.8, horperfopt@1.0.5, hydrateordiedrate@2.5.5, immersivequicklime@0.1.7, jsonpatcheslib@1.5.9, kilnshelves@1.1.8, millwright@1.3.4, minireeddistribution@1.0.2, molds@0.3.7, morepaperrecipes@2.0.0, overhaulliblegacycompat@1.2.9, overhaullib@2.0.10, primitivesurvival@5.1.3, racialequalityexpanded@0.1.6, racialequality@0.1.28, realisticmonsterloot@1.2.0, shelfobsessed@2.2.1, specialexpandedbags@2.0.0, stackedmetals@1.0.0, stonequarryrepckfipil@3.6.3, tankardsandgoblets@1.4.4, temporalsymphony@2.3.2, toolbelt@0.3.5, translocatorengineeringredux@1.6.6, trashmod@1.0.9, usefultraders@2.5.2, game@1.22.7, vsimgui@1.2.7, vspaint@1.2.8, arthursjournal@2.0.5, yetanotherarrowheadmold@1.0.3, aculinaryartillery@2.0.0-dev.22, alchemy@2.1.21, allclasses@2.3.2, ancientlib@1.0.0, ancienttoolsresinharvest@1.0.0, animationslib@0.0.2, anvilperformanceoptimization@1.0.0, attributerenderinglibrary@3.2.0, egocaribautomapmarkers@5.0.3, awearablelight@1.2.3-pre.2, bettererprospecting@3.4.7, betterruins@0.6.3, billposting@2.0.3, bloodtrail@1.2.5, blushlibrary@1.1.2, manifest@1.5.5, butchering@1.14.3, buzzwords@1.8.2, canadditionalmetals@1.1.2, canjewelry@0.7.1, cannibalism@1.3.0, carryonlib@1.0.0-pre.8, cartwrightscaravan@1.9.1, claypress@1.1.0, clothierheirloomsmod@1.1.0, composter@1.2.2, configlib@1.12.0, cooperativecombatrework@1.1.0, critchersgrapplehook@1.1.0, crossbowsfork@1.10.1, danatweaks@4.1.0, deathcorpses@2.8.1, unchained@1.9.0, emotes@2.8.1, tackandequipment@1.3.0, feverstonewilds@2.1.2, fillmybloomery@1.0.3, firearmsfork@1.10.2, firepitsshowfuel@2.0.0-dev.1, foodshelves@3.0.5, fromgoldencombs@2.0.8, gardenersdelight@1.0.2, genelib@3.2.0, homesteading@1.0.1, icecycle@1.0.2, immersivemodularbackpacks@1.7.6, ithaniacannedgoods@2.0.7, jaunt@3.1.0, kilnspreading@1.0.2, krpgenchantment@1.5.2, lensgemology@1.0.13, manureecology@1.2.1, metallurgy@1.2.1, moldsplus@1.0.4, ndlflowergrowth@2.6.0, ndlmushroomgrowth@2.4.3, ndltreegrowth@2.7.0, noofflinecontainerfoodspoil@2.0.2, panningmachine@1.1.1, petai@5.1.1, playerlistrevived@2.3.8, playermodellib@1.23.8, claywheel@2.0.1, realisticwater@0.3.2, rivers@5.0.3, rpvoicechat@2.6.2, rustboundmagic@3.2.5, shadehouse@1.5.2, simplebedspawn@1.0.1, slowtox@5.0.0, smithingplus@1.9.0-rc.1, stackedtemporalgear@1.0.0, stainedartifice@1.0.1, stonebakeoven@1.3.8, th3dungeon@1.0.2, improvedmetallurgy@1.1.8, universalhusbandry@1.2.1, vinconomy@5.3.0, vintagecanvas@1.2.6, vintagekinematics@1.4.2, creative@1.22.7, vsquest@3.1.0, vsroofing@1.7.2, vsserverpanel@0.5.8, survival@1.22.7, vsvillage@6.0.5, watersheds@7.0.4, wildvinegrow@1.0.7, xlibfork@1.0.36, ancienttoolsmortar@1.0.0, autoconfiglib@2.0.10, bigboards@1.0.5, billpostingextra@1.0.0, blushandbins@1.3.4, blushandblacksmith@1.1.2, bounties@1.0.7, canjewelryadornments@1.0.0, canjewelryxskill@0.1.7, carryon@2.0.0-pre.8, cats@5.0.2, danacancook@2.0.0, draconis@1.5.0, equus@1.4.0, expandedfoods@2.0.0-dev.14, em@3.8.1, mannyextrafirearms@1.1.3, feverstonewildsbutcheringcompatfork@2.8.0, fluffydreg@0.7.4, glockmaker@1.2.0, kcsdragons@0.9.17, koboldrdx@1.4.16, lupines@0.2.14, medievalarchitecture@1.1.1, modularbutcheringbag@1.0.2, obsidiancraft@2.0.0, pegasus@1.1.0-rc.1, plushiemodpack@3.0.0, quiversfork@0.9.31, realisticrapids@0.1.2, seraphleveling@1.20.1, shearlib@1.3.0, skeletons@0.6.2, storagetweaks@1.4.1-rc.3, tabletopgames@4.0.0, tailorsdelight@2.2.2, underwaterhorrors@0.19.0, vintagebirbs@0.6.0, waterwheelriver@1.2.1, wolftaming@5.0.1, xskillsfork@1.0.97, dragolerdragontraits@1.3.0-pre.1, bricklayers@3.3.0, butcheringseraphlevelingcompatibility@1.1.1, draconisrhinocroma@1.0.0, efchefstricks@1.0.0-dev.4, efmealsmodule@1.0.0-dev.8, sandwich@1.3.0, ashes@1.5.0, wool@1.9.5, xskillsgilded@1.3.51
Involved Harmony IDs: com.jakecool19.efrecipes.cookingoverhaul
System.ArgumentOutOfRangeException: Index was out of range. Must be non-negative and less than the size of the collection. (Parameter 'index')
   at Vintagestory.GameContent.CookingRecipe.GenerateRandomMeal_Patch1(CookingRecipe this, ICoreAPI api, Dictionary`2& cachedValidStacksByIngredient, ItemStack[] allstacks, Int32 slots, ItemStack ingredientStack)
   at Vintagestory.GameContent.GuiHandbookMealRecipePage.RenderListEntryTo(ICoreClientAPI capi, Single dt, Double x, Double y, Double cellWidth, Double cellHeight) in VSSurvivalMod\Systems\Handbook\Gui\GuiHandbookMealRecipePage.cs:line 149
   at Vintagestory.GameContent.GuiElementFlatList.RenderInteractiveElements(Single deltaTime) in VSSurvivalMod\Systems\Handbook\Gui\GuiElementFlatList.cs:line 225
   at Vintagestory.API.Client.GuiComposer.Render(Single deltaTime) in VintagestoryApi\Client\UI\GuiComposer.cs:line 737
   at Vintagestory.API.Client.GuiDialog.OnRenderGUI(Single deltaTime) in VintagestoryApi\Client\UI\Dialog\GuiDialog.cs:line 398
   at Vintagestory.GameContent.GuiDialogHandbook.OnRenderGUI(Single deltaTime) in VSSurvivalMod\Systems\Handbook\Gui\GuiDialogHandbook.cs:line 547
   at Vintagestory.Client.NoObf.GuiManager.OnRenderFrameGUI(Single deltaTime) in VintagestoryLib\Client\Systems\Gui\GuiManager.cs:line 309
   at Vintagestory.Client.NoObf.ClientMain.RenderToDefaultFramebuffer(Single dt) in VintagestoryLib\Client\ClientMain.cs:line 1048
   at Vintagestory.Client.GuiScreenRunningGame.RenderToDefaultFramebuffer(Single dt) in VintagestoryLib\Client\MainMenu\Screens\GuiScreenRunningGame.cs:line 251
   at Vintagestory.Client.ScreenManager.Render(Single dt) in VintagestoryLib\Client\ScreenManager.cs:line 783
   at Vintagestory.Client.ScreenManager.OnNewFrame(Single dt) in VintagestoryLib\Client\ScreenManager.cs:line 686
   at Vintagestory.Client.NoObf.ClientPlatformWindows.window_RenderFrame(FrameEventArgs e) in VintagestoryLib\Client\ClientPlatform\GameWindow.cs:line 112
   at OpenTK.Windowing.Desktop.GameWindow.Run()
   at Vintagestory.Client.ClientProgram.Start(ClientProgramArgs args, String[] rawArgs) in VintagestoryLib\Client\ClientProgram.cs:line 354
   at Vintagestory.Client.ClientProgram.<>c__DisplayClass10_0.<.ctor>b__1() in VintagestoryLib\Client\ClientProgram.cs:line 131
   at Vintagestory.ClientNative.CrashReporter.Start(ThreadStart start) in VintagestoryLib\Client\ClientPlatform\ClientNative\CrashReporter.cs:line 95

Event Log entries for Vintagestory.exe, the latest 3
==================================
{ TimeGenerated = 8/30/2026 5:21:36 PM, Site = , Source = Application Error, Message = Faulting application name: Vintagestory.exe, version: 1.22.7.0, time stamp: 0x693c0000
Faulting module name: openal32.dll, version: 1.23.0.0, time stamp: 0x63dd31ad
Exception code: 0x40000015
Fault offset: 0x00000000000df046
Faulting process id: 0xdc80
Faulting application start time: 0x1dd38c2da8233db
Faulting application path: E:\Vintagestory\Vintagestory.exe
Faulting module path: E:\Vintagestory\Lib\openal32.dll
Report Id: 44976830-9e66-4d08-be7c-34376368ebb2
Faulting package full name: 
Faulting package-relative application ID:  }
--------------
{ TimeGenerated = 8/30/2026 4:39:10 PM, Site = , Source = Application Error, Message = Faulting application name: Vintagestory.exe, version: 1.22.7.0, time stamp: 0x693c0000
Faulting module name: KERNELBASE.dll, version: 10.0.26100.9168, time stamp: 0xef4c9cab
Exception code: 0xe0434352
Fault offset: 0x00000000000c187a
Faulting process id: 0xa63c
Faulting application start time: 0x1dd38beb1e54086
Faulting application path: E:\Vintagestory\Vintagestory.exe
Faulting module path: C:\WINDOWS\System32\KERNELBASE.dll
Report Id: e7c61806-1e36-4dee-b792-04c2998044c5
Faulting package full name: 
Faulting package-relative application ID:  }
--------------
{ TimeGenerated = 8/24/2026 2:39:25 AM, Site = , Source = Application Error, Message = Faulting application name: Vintagestory.exe, version: 1.22.7.0, time stamp: 0x693c0000
Faulting module name: nvoglv64.dll, version: 32.0.16.1088, time stamp: 0x6a601674
Exception code: 0xc0000409
Fault offset: 0x00000000010cbbed
Faulting process id: 0x75e8
Faulting application start time: 0x1dd337e5d317712
Faulting application path: E:\Vintagestory\Vintagestory.exe
Faulting module path: C:\WINDOWS\System32\DriverStore\FileRepository\nv_dispi.inf_amd64_0373d825005116d0\nvoglv64.dll
Report Id: a06e1c80-e3e6-49a8-9adb-5633946958cf
Faulting package full name: 
Faulting package-relative application ID:  }
```