### PR TITLE
Removed the unnecessary division operation after the check on whether…

### DIFF
--- a/Item/ItemExpandedRawFood.cs
+++ b/Item/ItemExpandedRawFood.cs
@@ -152,7 +152,6 @@ namespace ACulinaryArtillery
             output.Attributes["madeWith"] = new StringArrayAttribute([.. ingredients.Order()]);
             if (output.Collectible is not ItemExpandedLiquid)
             {
-                sat = Array.ConvertAll(sat, i => i / output.StackSize);
                 output.Attributes.RemoveAttribute("waterTightContainerProps");
             }
             output.Attributes["expandedSats"] = new FloatArrayAttribute([.. sat]);


### PR DESCRIPTION
… the output of a simmer recepe will not be an ItemExpandedLiquid. This fixes the problem of recipes like fruit leather giving diminishing extra sats when simmered in larger batches.